### PR TITLE
New ResultSet methods in 1.7 that need to be overriden

### DIFF
--- a/src/commondb/mock/MockResultSet.java
+++ b/src/commondb/mock/MockResultSet.java
@@ -415,6 +415,16 @@ public class MockResultSet implements ResultSet {
 	}
 
 	@Override
+	public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+		throw new UnsupportedOperationException("to be implemented");
+	}
+
+	@Override
+	public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+		throw new UnsupportedOperationException("to be implemented");
+	}
+
+	@Override
 	public Ref getRef(int columnIndex) throws SQLException {
 		throw new UnsupportedOperationException("to be implemented");
 	}


### PR DESCRIPTION
ResultSet in Java 1.7 has 2 new methods that need to be overridden.
Unfortunately this is a breaking change from Java 1.6... maybe it's OK to leave out the @Override keyword?
